### PR TITLE
updated getOrderDetails to use fragment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cheapreats/ts-sdk",
-  "version": "1.13.17",
+  "version": "1.13.18",
   "description": "CheaprEats Typescript SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cheapreats/ts-sdk",
-  "version": "1.13.16",
+  "version": "1.13.17",
   "description": "CheaprEats Typescript SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/app/controllers/OrderController.ts
+++ b/src/app/controllers/OrderController.ts
@@ -438,10 +438,7 @@ export class OrderController {
                       ...OrderFragment
                     }
                 }
-                ` 
-                +  OrderFragment +
-                `
-            `;
+                ` +  OrderFragment;
       this.app
         .getAdaptor()
         .mutate(mutationString, {

--- a/src/app/controllers/OrderController.ts
+++ b/src/app/controllers/OrderController.ts
@@ -10,6 +10,76 @@ import { ModifierChoiceInput } from "./ModifierController";
 import { MutateResult } from "../links/synchronouslinks/GraphQLLink";
 import { OrderStatusIdentifier, OrderPaymentMethod, OrderType, OrderCancellationReason } from "../../enums";
 
+const OrderFragment = `
+
+fragment OrderFragment on Order {
+  _id
+  items {
+    _id
+  }
+  transactions { 
+    _id
+    data {
+      id
+      amount
+      captured
+      created
+    }
+    status
+    refund {
+      id
+      amount
+      status
+      created
+    }
+    charge_type
+  }
+  customer {
+    _id
+  }
+  vendor {
+    _id
+  }
+  subtotal
+  total
+  note
+  payment_method
+  status_history {
+    name
+    identifier
+    data
+    created_at
+  }
+  scheduled_pickup
+  status
+  cancel_reason
+  cancel_description
+  settled_at
+  preparing_at
+  estimated_preparing_sec
+  attached_survey {
+    _id
+  }
+  attached_survey_response { 
+    _id
+    customer {
+      _id
+    }
+  }
+  order_type
+  discount
+  participating_customers {
+    customer_id
+    payment_method
+    amount_paying_percentage
+    tip {
+      amount
+      description
+    }
+  }
+}
+`
+
 export interface CreateOrderModifierInput {
   modifier_id: string;
   choices: Array<string>;
@@ -365,9 +435,12 @@ export class OrderController {
       let mutationString = `
                 query getOrderDetails ($orderId: String!){
                     getOrderDetails(order_id: $orderId) {
-                        _id
+                      ...OrderFragment
                     }
                 }
+                ` 
+                +  OrderFragment +
+                `
             `;
       this.app
         .getAdaptor()


### PR DESCRIPTION
The getOrderDetails query should return the order object, not just the _id of the object